### PR TITLE
CI - Adding grcov reporting into pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - ci/coverage
   pull_request:
     types: [opened]
 
@@ -28,8 +29,7 @@ jobs:
 
       - name: Run tests with coverage flags
         env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zinstrument-coverage'
+          RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'coverage-%p-%m.profraw'
         run: cargo test --all-features
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: atomizer main pipeline
+# Build project and run some tests hopefully.
+
+on:
+  push:
+  pull_request:
+    types: [opened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # 😔😔😔
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: cargo build --release
+      - run: cargo test --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo build --release
 
-  coverage: #no use testing something that doesn't compile...
+  coverage:
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -36,18 +36,18 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          mkdir coverage
+          mkdir -p coverage
           grcov . \
             --binary-path ./target/debug/ \
             -s . \
-            -t html \
+            -t lcov \
             --branch \
             --ignore-not-existing \
             --ignore "/*" \
-            -o coverage/
+            -o coverage/lcov.info
 
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+      - name: Report coverage
+        uses: zgosalvez/github-actions-report-lcov@v4
         with:
-          name: coverage-html
-          path: coverage/
+          coverage-files: coverage/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,50 @@ name: atomizer main pipeline
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [opened]
 
 jobs:
   build:
-    runs-on: ubuntu-latest # 😔😔😔
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - run: cargo build --release
-      - run: cargo test --all-features
+
+  coverage: #no use testing something that doesn't compile...
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install grcov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lcov
+          cargo install grcov
+
+      - name: Run tests with coverage flags
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zinstrument-coverage'
+          LLVM_PROFILE_FILE: 'coverage-%p-%m.profraw'
+        run: cargo test --all-features
+
+      - name: Generate coverage report
+        run: |
+          mkdir coverage
+          grcov . \
+            --binary-path ./target/debug/ \
+            -s . \
+            -t html \
+            --branch \
+            --ignore-not-existing \
+            --ignore "/*" \
+            -o coverage/
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     needs: build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,8 @@ on:
   push:
     branches:
       - main
-      - ci/coverage
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y lcov
+          rustup component add llvm-tools
           cargo install grcov
 
       - name: Run tests with coverage flags
         env:
+          CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'coverage-%p-%m.profraw'
         run: cargo test --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install grcov
         run: |
-          sudo apt-get update
           sudo apt-get install -y lcov
           rustup component add llvm-tools
           cargo install grcov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-build-
 
+      - name: Cache cargo bin (for grcov and other tools)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-grcov-${{ hashFiles('.github/workflows/build.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bin-grcov-
+
       - name: Install grcov
         run: |
           sudo apt-get install -y lcov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,25 +5,63 @@ on:
   push:
     branches:
       - main
-      - ci/coverage
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
       - run: cargo build --release
 
-  coverage: #no use testing something that doesn't compile...
+  coverage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     needs: build
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-
+
       - name: Install grcov
         run: |
-          sudo apt-get update
           sudo apt-get install -y lcov
           rustup component add llvm-tools
           cargo install grcov
@@ -33,22 +71,35 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'coverage-%p-%m.profraw'
-        run: cargo test --all-features
+        run: |
+          cargo test --all-features > test-results.log
 
       - name: Generate coverage report
         run: |
-          mkdir coverage
+          mkdir -p coverage
           grcov . \
             --binary-path ./target/debug/ \
             -s . \
-            -t html \
+            -t lcov \
             --branch \
             --ignore-not-existing \
             --ignore "/*" \
-            -o coverage/
+            -o coverage/lcov.info
 
-      - name: Upload coverage report
+      - name: Report coverage
+        uses: zgosalvez/github-actions-report-lcov@v4
+        with:
+          coverage-files: coverage/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload test results artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html
-          path: coverage/
+          name: test-results
+          path: test-results.log
+
+      - name: Comment test results on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: test-results.log


### PR DESCRIPTION
the build workflow (should) now include the coverage reports as artifacts in the repository using grcov. Coverage will be checked after compilation, since it doesn't make sense testing what doesn't even compile...

## notes
- This PR is a draft to prevent it from already running. 'Opening' this PR should make this workflow run
  -  This is to prevent wasting CI time. It would be nice to actually test this on the runners
- This PR brings eff2e02562a7ff02561e21f2a1fb207ab111f4db into v1.0.0